### PR TITLE
Error handling

### DIFF
--- a/models/general.go
+++ b/models/general.go
@@ -1,0 +1,12 @@
+package models
+
+type APIError struct {
+	OK        bool        `json:"ok"`
+	ErrorCode string      `json:"code"`
+	ErrorInfo interface{} `json:"info"`
+}
+
+type APIResponse struct {
+	OK   bool        `json:"ok"`
+	Data interface{} `json:"data"`
+}


### PR DESCRIPTION
This PR adds error handling for API responses, as well as a standardised container for responses.

Here's how I propose to do this - @Skwunk if you have other ideas I'm all ears:

All API responses will have an `ok` field - if everything worked it's `true`, if there was an error it's `false`.

If everything worked, the response will have a `data` field, with the result.

If the API shat the bed, it will have fields `code` and `info`. The code should be some unique code for what went wrong (note that this does not replace using a sensible HTTP status code, instead complementing it), the info should be some description of the error (can be nil - e.g. for internal errors)